### PR TITLE
Update .platform.app.yaml

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -24,12 +24,12 @@ variables:
 hooks:
     build: |
         set -e
-        bin/console assets:install --no-debug
-        bin/console cache:clear
+        php bin/console assets:install --no-debug
+        php bin/console cache:clear
     deploy: |
         set -e
-        bin/console assets:install --symlink --relative public
-        bin/console cache:clear
+        php bin/console assets:install --symlink --relative public
+        php bin/console cache:clear
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed


### PR DESCRIPTION
for symfony 5.3.4 because call bin/console directly get error permission
https://github.com/platformsh-templates/symfony5/issues/20

in 5.3.4 bin/console is completely different that 5.2 from platformsh-templates/symfony5